### PR TITLE
Issue#24

### DIFF
--- a/sgs/api.py
+++ b/sgs/api.py
@@ -8,7 +8,6 @@ from retrying import retry
 from .common import LRU_CACHE_SIZE, MAX_ATTEMPT_NUMBER, to_datetime
 
 
-
 @retry(stop_max_attempt_number=MAX_ATTEMPT_NUMBER)
 @functools.lru_cache(maxsize=LRU_CACHE_SIZE)
 def get_data(ts_code: int, begin: str, end: str) -> List:
@@ -22,7 +21,6 @@ def get_data(ts_code: int, begin: str, end: str) -> List:
     )
     request_url = url.format(ts_code, begin, end)
     response = requests.get(request_url)
-
     return response.json()
     
 def get_data_with_strict_range(ts_code: int, begin: str, end: str) -> List:

--- a/sgs/api.py
+++ b/sgs/api.py
@@ -5,12 +5,13 @@ import pandas as pd
 import requests
 from retrying import retry
 
-from .common import LRU_CACHE_SIZE, MAX_ATTEMPT_NUMBER
+from .common import LRU_CACHE_SIZE, MAX_ATTEMPT_NUMBER, to_datetime
+
 
 
 @retry(stop_max_attempt_number=MAX_ATTEMPT_NUMBER)
 @functools.lru_cache(maxsize=LRU_CACHE_SIZE)
-def get_data(ts_code: int, begin: str, end: str) -> List:
+def get_data(ts_code: int, begin: str, end: str, strict: bool = False) -> List:
     """
     Requests time series data from the SGS API in json format.
     """
@@ -21,4 +22,41 @@ def get_data(ts_code: int, begin: str, end: str) -> List:
     )
     request_url = url.format(ts_code, begin, end)
     response = requests.get(request_url)
-    return response.json()
+    
+    if strict:
+        data = enforce_integrity(response.json(), begin, end)
+    else:
+        data = response.json()
+    
+    return data
+    
+def enforce_integrity(data_from_sgs: list, start: str, end: str) -> List:
+    """
+    Enforce integrity
+    
+    SGS API default behaviour returns the last stored value when selected period have no data.
+
+    It is possible to catch this behaviour when the first record date precedes the start date.
+    
+    This function enforces an empty data set when the first record date precedes the start date.
+    
+    :param data_from_sgs: List containing data from sgs.
+    :param start: start date (DD/MM/YYYY).
+    :param end: end date (DD/MM/YYYY).
+  
+    :return: List containing data from sgs or an empty list
+    :rtype: list
+
+    """
+
+    first_record_date = to_datetime(data_from_sgs[0]["data"], "pt")
+    period_start_date = to_datetime(start, 'pt')
+
+    is_out_of_range =  first_record_date < period_start_date
+    
+    if is_out_of_range:
+        ts_data = []
+    else:
+        ts_data = data_from_sgs
+    
+    return ts_data

--- a/sgs/api.py
+++ b/sgs/api.py
@@ -52,10 +52,10 @@ def get_data_with_strict_range(ts_code: int, begin: str, end: str) -> List:
         if is_out_of_range:
             raise ValueError
     except TypeError:
-        print("ERROR: Please, use format 'DD/MM/YYYY' for date strings.")
+        print("ERROR: Serie " + str(ts_code) + " - Please, use 'DD/MM/YYYY' format for date strings.")
         data = []
     except ValueError:
-        print("WARNING: There is no data for requested period, but there's data before.")
+        print("WARNING: Serie " + str(ts_code) + " - There is no data for the requested period, but there's previous data.")
         data = []
     
     return data

--- a/sgs/dataframe.py
+++ b/sgs/dataframe.py
@@ -17,7 +17,7 @@ def dataframe(ts_codes: Union[int, List, Tuple], start: str, end: str, strict: b
     :param ts_codes: single code or list/tuple of time series codes.
     :param start: start date (DD/MM/YYYY).
     :param end: end date (DD/MM/YYYY).
-    :param strict: boolean used to enforce integrity.
+    :param strict: boolean to enforce a strict date range.
 
     :return: Pandas dataframe.
     :rtype: pandas.DataFrame_

--- a/sgs/dataframe.py
+++ b/sgs/dataframe.py
@@ -10,13 +10,14 @@ from . import search
 from .ts import time_serie
 
 
-def dataframe(ts_codes: Union[int, List, Tuple], start: str, end: str) -> pd.DataFrame:
+def dataframe(ts_codes: Union[int, List, Tuple], start: str, end: str, strict: bool = False) -> pd.DataFrame:
     """
     Creates a dataframe from a list of time serie codes.
 
     :param ts_codes: single code or list/tuple of time series codes.
     :param start: start date (DD/MM/YYYY).
     :param end: end date (DD/MM/YYYY).
+    :param strict: boolean used to enforce integrity.
 
     :return: Pandas dataframe.
     :rtype: pandas.DataFrame_
@@ -40,7 +41,7 @@ def dataframe(ts_codes: Union[int, List, Tuple], start: str, end: str) -> pd.Dat
 
     series = []
     for code in ts_codes:
-        ts = time_serie(code, start, end)
+        ts = time_serie(code, start, end, strict)
         series.append(ts)
 
     df = pd.concat(series, axis=1)

--- a/sgs/ts.py
+++ b/sgs/ts.py
@@ -11,13 +11,14 @@ from . import search
 from .common import to_datetime
 
 
-def time_serie(ts_code: int, start: str, end: str) -> pd.Series:
+def time_serie(ts_code: int, start: str, end: str, strict: bool = False) -> pd.Series:
     """
     Request a time serie data.
 
     :param ts_code: time serie code.
     :param start: start date (DD/MM/YYYY).
     :param end: end date (DD/MM/YYYY).
+    :param strict: boolean used to enforce integrity.
 
     :return: Time serie values as pandas Series indexed by date.
     :rtype: pandas.Series_
@@ -25,7 +26,7 @@ def time_serie(ts_code: int, start: str, end: str) -> pd.Series:
     Usage::
 
         >>> CDI = 12
-        >>> ts = sgs.time_serie(CDI_CODE, start='02/01/2018', end='31/12/2018')
+        >>> ts = sgs.time_serie(CDI, start='02/01/2018', end='31/12/2018')
         >>> ts.head()
         2018-01-02    0.026444
         2018-01-03    0.026444
@@ -34,10 +35,9 @@ def time_serie(ts_code: int, start: str, end: str) -> pd.Series:
         2018-01-08    0.026444
     """
 
-    ts_data = {"values": [], "index": []}  # type: Dict[str, List]
     values = []
     index = []
-    for i in api.get_data(ts_code, start, end):
+    for i in api.get_data(ts_code, start, end, strict):
         values.append(i["valor"])
         index.append(to_datetime(i["data"], "pt"))
 

--- a/sgs/ts.py
+++ b/sgs/ts.py
@@ -18,7 +18,7 @@ def time_serie(ts_code: int, start: str, end: str, strict: bool = False) -> pd.S
     :param ts_code: time serie code.
     :param start: start date (DD/MM/YYYY).
     :param end: end date (DD/MM/YYYY).
-    :param strict: boolean used to enforce integrity.
+    :param strict: boolean to enforce a strict date range.
 
     :return: Time serie values as pandas Series indexed by date.
     :rtype: pandas.Series_
@@ -34,6 +34,7 @@ def time_serie(ts_code: int, start: str, end: str, strict: bool = False) -> pd.S
         2018-01-05    0.026444
         2018-01-08    0.026444
     """
+    
     if strict:
         ts_data = api.get_data_with_strict_range(ts_code, start, end)
     else:

--- a/sgs/ts.py
+++ b/sgs/ts.py
@@ -34,10 +34,14 @@ def time_serie(ts_code: int, start: str, end: str, strict: bool = False) -> pd.S
         2018-01-05    0.026444
         2018-01-08    0.026444
     """
-
+    if strict:
+        ts_data = api.get_data_with_strict_range(ts_code, start, end)
+    else:
+        ts_data = api.get_data(ts_code, start, end)
+        
     values = []
     index = []
-    for i in api.get_data(ts_code, start, end, strict):
+    for i in ts_data:
         values.append(i["valor"])
         index.append(to_datetime(i["data"], "pt"))
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -12,7 +12,9 @@ def test_get_data():
     assert len(data) == NUMBER_OF_LINES
     
 @pytest.mark.api
-def test_enforce_integrity():
-    data = api.get_data(20577, "17/08/2019", "18/08/2019", True)
+def test_get_data_with_strict_range():
+    NUMBER_OF_LINES = 0
+    data = api.get_data_with_strict_range(20577, "17/08/2019", "18/08/2019")
     assert isinstance(data, list)
-    assert len(data) == 0
+    assert len(data) == NUMBER_OF_LINES
+

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -10,3 +10,9 @@ def test_get_data():
     data = api.get_data(4, "02/01/2018", "31/01/2018")
     assert isinstance(data, list)
     assert len(data) == NUMBER_OF_LINES
+    
+@pytest.mark.api
+def test_enforce_integrity():
+    data = api.get_data(20577, "17/08/2019", "18/08/2019", True)
+    assert isinstance(data, list)
+    assert len(data) == 0

--- a/tests/test_dataframe.py
+++ b/tests/test_dataframe.py
@@ -13,3 +13,25 @@ def test_dataframe_multiple_ts():
     ts_codes = [12, 433]
     df = dataframe(ts_codes, start="02/01/2018", end="31/01/2018")
     assert df.shape == (23, 2)
+    
+@pytest.mark.dataframe
+def test_dataframe_one_with_strict_as_false():
+    df = dataframe(20577, start='17/08/2019', end='18/08/2019')
+    assert df.shape == (1, 1)
+
+@pytest.mark.dataframe
+def test_dataframe_one_with_strict_as_true():
+    df = dataframe(20577, start='17/08/2019', end='18/08/2019', strict=True)
+    assert df.shape == (0, 1)
+
+@pytest.mark.dataframe
+def test_dataframe_multiple_with_strict_as_false():
+    ts_codes = [20577,20669]
+    df = dataframe(ts_codes, start='17/08/2019', end='18/08/2019')
+    assert df.shape == (1, 2)
+
+@pytest.mark.dataframe
+def test_dataframe_multiple_with_strict_as_true():
+    ts_codes = [20577,20669]
+    df = dataframe(ts_codes, start='17/08/2019', end='18/08/2019', strict=True)
+    assert df.shape == (0, 2)

--- a/tests/test_ts.py
+++ b/tests/test_ts.py
@@ -16,3 +16,15 @@ def test_ts_with_null_values():
     ts = time_serie(21554, start="31/12/1992", end="01/06/2019")
     data = ts.loc['1994-04-01']    
     assert np.isnan(data) == True
+   
+@pytest.mark.ts
+def test_ts_with_strict_as_false():
+    ts = time_serie(20577, "17/08/2019", "18/08/2019")
+    assert len(ts) == 1
+    assert ts.dtype == np.float
+    
+@pytest.mark.ts
+def test_ts_with_strict_as_true():
+    ts = time_serie(20577, "17/08/2019", "18/08/2019", True)
+    assert len(ts) == 0
+    assert ts.dtype == np.float


### PR DESCRIPTION
Abordagem para a Issue #24 .

**Problema:**

Quando o usuario consulta uma série para um intervalo de datas sem registros, a API do SGS retorna, por padrão, o último valor armazenado para esta série.

Este comportamento é potencialmente perigoso quando a biblioteca é utilizada em automações sem os devidos controles.

**Abordagem**

As funções `time_serie`e `dataframe` foram alteradas para receber um argumento opcional: `strict`. Este argumento é um booleano com valor default False.

O valor default garante o atual funcionamento da biblioteca, evitando quebras de código. 

Caso `strict=True`, os registros com data anterior ao período solicitado pelo usuário são descartados, garantindo um conjunto de retorno vazio.

Adicionalmente, o usuário recebe um aviso:

Exemplo da função `time_serie`:
```
>>> import sgs
>>> ts = sgs.time_serie(20577, start='17/08/2019', end='18/08/2019')
>>> ts
2019-08-01    209648.0
Name: 20577, dtype: float64
>>> ts = sgs.time_serie(20577, start='17/08/2019', end='18/08/2019', strict=True)
WARNING: Serie 20577 - There is no data for the requested period, but there's previous data.
>>> ts
Series([], Name: 20577, dtype: float64)
>>> 
```
Exemplo da função `dataframe`:
```
>>> import sgs
>>> df = sgs.dataframe([20577, 20669, 20745, 21117, 20882], start='17/08/2019', end='18/08/2019', strict=True)
WARNING: Serie 20577 - There is no data for the requested period, but there's previous data.
WARNING: Serie 20669 - There is no data for the requested period, but there's previous data.
WARNING: Serie 20745 - There is no data for the requested period, but there's previous data.
WARNING: Serie 21117 - There is no data for the requested period, but there's previous data.
WARNING: Serie 20882 - There is no data for the requested period, but there's previous data.
>>> df
Empty DataFrame
Columns: [20577, 20669, 20745, 21117, 20882]
Index: []

```