### PR TITLE
Fix json decode error (http > https)

### DIFF
--- a/sgs/api.py
+++ b/sgs/api.py
@@ -16,7 +16,7 @@ def get_data(ts_code: int, begin: str, end: str) -> List:
     """
 
     url = (
-        "http://api.bcb.gov.br/dados/serie/bcdata.sgs.{}"
+        "https://api.bcb.gov.br/dados/serie/bcdata.sgs.{}"
         "/dados?formato=json&dataInicial={}&dataFinal={}"
     )
     request_url = url.format(ts_code, begin, end)

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -100,7 +100,7 @@ def test_search_by_text_query_returns_multiple_result_pages():
 def test_search_by_text_multiple_results():
     results = search_ts("dolar", "pt")
     assert isinstance(results, list)
-    result_count = 41
+    result_count = 43
     assert len(results) == result_count
     assert results[0]["code"] == 1
-    assert results[-1]["code"] == 21636
+    assert results[-1]["code"] == 29372


### PR DESCRIPTION
A url (http) antiga do BCB-SGS não funciona mais. Mudaram para https.

Por exemplo, funciona:
https://api.bcb.gov.br/dados/serie/bcdata.sgs.20542/dados?formato=json

Não funciona:
http://api.bcb.gov.br/dados/serie/bcdata.sgs.20542/dados?formato=json

Fiz a alteração para https e arrumei um test que estava desatualizado.